### PR TITLE
Chart/enhancements

### DIFF
--- a/src/components/pages/trading/Positions/PositionBlock.tsx
+++ b/src/components/pages/trading/Positions/PositionBlock.tsx
@@ -297,7 +297,12 @@ export default function PositionBlock({
           <div className="flex w-full font-mono text-xxs text-txtfade justify-center items-center">
             Liq. Price
           </div>
-          <div className="flex">
+          <div
+            className="flex cursor-pointer hover:bg-gray-100 hover:bg-opacity-10 transition-colors duration-100 p-1 rounded"
+            onClick={() => triggerEditPositionCollateral(position)}
+            role="button"
+            tabIndex={0}
+          >
             <FormatNumber
               nb={position.liquidationPrice}
               format="currency"
@@ -310,8 +315,12 @@ export default function PositionBlock({
           <div className="flex w-full font-mono text-xxs justify-center items-center text-txtfade">
             Take Profit
           </div>
-
-          <div className="flex">
+          <div
+            className="flex cursor-pointer hover:bg-gray-100 hover:bg-opacity-10 transition-colors duration-100 p-1 rounded"
+            onClick={() => triggerStopLossTakeProfit(position)}
+            role="button"
+            tabIndex={0}
+          >
             {position.takeProfitThreadIsSet &&
             position.takeProfitLimitPrice &&
             position.takeProfitLimitPrice > 0 ? (
@@ -330,8 +339,12 @@ export default function PositionBlock({
           <div className="flex w-full font-mono text-xxs justify-center items-center text-txtfade">
             Stop Loss
           </div>
-
-          <div className="flex">
+          <div
+            className="flex cursor-pointer hover:bg-gray-100 hover:bg-opacity-10 transition-colors duration-100 p-1 rounded"
+            onClick={() => triggerStopLossTakeProfit(position)}
+            role="button"
+            tabIndex={0}
+          >
             {position.stopLossThreadIsSet &&
             position.stopLossLimitPrice &&
             position.stopLossLimitPrice > 0 ? (

--- a/src/components/pages/trading/TradingChart/TradingChart.tsx
+++ b/src/components/pages/trading/TradingChart/TradingChart.tsx
@@ -1,11 +1,10 @@
 import { PublicKey } from '@solana/web3.js';
-import Link from 'next/link';
 import React, { MutableRefObject, useEffect, useRef, useState } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 import Loader from '@/components/Loader/Loader';
 import { PositionExtended, Token } from '@/types';
-import { formatNumber } from '@/utils';
+import { formatNumber, formatNumberShort } from '@/utils';
 
 import {
   IChartingLibraryWidget,
@@ -21,7 +20,7 @@ let tvScriptLoadingPromise: Promise<unknown>;
 type Widget = IChartingLibraryWidget;
 const greenColor = '#07956be6';
 const redColor = '#c9243ae6';
-// const greyColor = '#78828e';
+const greyColor = '#78828e';
 const whiteColor = '#ffffff';
 const orangeColor = '#f77f00';
 const blueColor = '#3a86ff';
@@ -41,6 +40,9 @@ function createEntryPositionLine(
     .setBodyBackgroundColor(color)
     .setBodyBorderColor(color)
     .setBodyTextColor(whiteColor)
+    .setQuantity('$'+formatNumberShort(position.sizeUsd, 0))
+    .setQuantityBackgroundColor(greyColor)
+    .setQuantityBorderColor(greyColor)
 }
 
 function createLiquidationPositionLine(
@@ -55,10 +57,13 @@ function createLiquidationPositionLine(
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       .setPrice(position.liquidationPrice!) // Price is checked before calling function
       .setLineColor(orangeColor)
-      .setLineStyle(2)
+      .setLineStyle(1)
       .setBodyBorderColor(orangeColor)
       .setBodyBackgroundColor(orangeColor)
       .setBodyTextColor(whiteColor)
+      .setQuantity('$'+formatNumberShort(position.sizeUsd, 0))
+      .setQuantityBackgroundColor(greyColor)
+      .setQuantityBorderColor(greyColor)
   );
 }
 
@@ -94,10 +99,13 @@ function createTakeProfitPositionLine(
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       .setPrice(position.takeProfitLimitPrice!)
       .setLineColor(blueColor)
-      .setLineStyle(2)
+      .setLineStyle(1)
       .setBodyBorderColor(blueColor)
       .setBodyBackgroundColor(blueColor)
       .setBodyTextColor(whiteColor)
+      .setQuantity('$'+formatNumberShort(position.sizeUsd, 0))
+      .setQuantityBackgroundColor(greyColor)
+      .setQuantityBorderColor(greyColor)
   );
 }
 
@@ -114,10 +122,13 @@ function createStopLossPositionLine(
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       .setPrice(position.stopLossLimitPrice!)
       .setLineColor(blueColor)
-      .setLineStyle(2)
+      .setLineStyle(1)
       .setBodyBorderColor(blueColor)
       .setBodyBackgroundColor(blueColor)
       .setBodyTextColor(whiteColor)
+      .setQuantity('$'+formatNumberShort(position.sizeUsd, 0))
+      .setQuantityBackgroundColor(greyColor)
+      .setQuantityBorderColor(greyColor)
   );
 }
 
@@ -470,16 +481,6 @@ export default function TradingChart({
         )}
       >
         <div id="chart-area" className="h-full flex flex-col rounded-b-lg" />
-        <div className="copyright text-[0.3em] bg-secondary flex items-center text-center italic pt-2 pb-2 pr-4 text-[#ffffffA0] justify-center md:justify-end">
-          TradingView™️ 
-          <Link
-            href={`https://www.tradingview.com/symbols/${token.symbol === 'WBTC' ? 'BTC' : token.symbol !== 'JITOSOL' ? token.symbol : 'SOL'}USD/`}
-            target="__blank"
-            className="ml-1 underline"
-          >
-            {token.symbol === 'WBTC' ? 'BTC' : token.symbol !== 'JITOSOL' ? token.symbol : 'SOL'} USD Chart
-          </Link>
-        </div>
       </div>
     </div>
   );

--- a/src/components/pages/trading/TradingChart/TradingChart.tsx
+++ b/src/components/pages/trading/TradingChart/TradingChart.tsx
@@ -457,7 +457,7 @@ export default function TradingChart({
       <div
         id="wrapper-trading-chart"
         className={twMerge(
-          'h-full w-full flex flex-col',
+          'h-full w-full flex flex-col min-h-[600px]',
           isLoading ? 'hidden' : '',
         )}
       >

--- a/src/components/pages/trading/TradingChartHeader/TradingChartHeader.tsx
+++ b/src/components/pages/trading/TradingChartHeader/TradingChartHeader.tsx
@@ -94,7 +94,8 @@ export default function TradingChartHeader({
                   title: `${
                     token.symbol === 'WBTC' ? 'BTC' : 
                     token.symbol !== 'JITOSOL' ? token.symbol : 'SOL'
-                  } / USD`,
+                    } / USD`,
+                  img: token.image,
                 };
               })}
             onSelect={(opt: string) => {

--- a/src/components/pages/trading/TradingChartHeader/TradingChartHeader.tsx
+++ b/src/components/pages/trading/TradingChartHeader/TradingChartHeader.tsx
@@ -7,7 +7,6 @@ import FormatNumber from '@/components/Number/FormatNumber';
 import useDailyStats from '@/hooks/useDailyStats';
 import { useSelector } from '@/store/store';
 import { Token } from '@/types';
-import { formatNumber } from '@/utils';
 
 export function getTokenSymbolFromChartFormat(tokenSymbol: string) {
   return tokenSymbol.slice(0, tokenSymbol.length - ' / USD'.length);
@@ -36,6 +35,7 @@ export default function TradingChartHeader({
 
     const price =
       streamingTokenPrices[
+        selected.symbol === 'WBTC' ? 'BTC' : 
         selected.symbol !== 'JITOSOL' ? selected.symbol : 'SOL'
       ];
 
@@ -54,6 +54,7 @@ export default function TradingChartHeader({
   useEffect(() => {
     setPreviousTokenPrice(
       streamingTokenPrices[
+        selected.symbol === 'WBTC' ? 'BTC' : 
         selected.symbol !== 'JITOSOL' ? selected.symbol : 'SOL'
       ] || 0,
     );
@@ -66,22 +67,24 @@ export default function TradingChartHeader({
       <Head>
         <title>
           {streamingTokenPrices[
+            selected.symbol === 'WBTC' ? 'BTC' : 
             selected.symbol !== 'JITOSOL' ? selected.symbol : 'SOL'
           ]?.toFixed(2) || 0}{' '}
-          – {selected.symbol !== 'JITOSOL' ? selected.symbol : 'SOL'} / USD
+          – {selected.symbol === 'WBTC' ? 'BTC' : selected.symbol !== 'JITOSOL' ? selected.symbol : 'SOL'} / USD
         </title>
       </Head>
       <div
         className={twMerge(
-          'flex flex-col sm:flex-row items-center justify-between sm:gap-3 z-30 bg-main border-b',
+          'flex flex-col sm:flex-row items-center justify-between sm:gap-3 z-30 bg-main border-b p-1',
           className,
         )}
       >
         <div className="flex items-center w-full sm:w-[200px] border-b border-r-none sm:border-b-0 sm:border-r">
           <Select
             className="w-full"
-            selectedClassName="py-3 px-2 sm:px-3"
+            selectedClassName="py-1 px-2 sm:px-2"
             selected={`${
+              selected.symbol === 'WBTC' ? 'BTC' : 
               selected.symbol !== 'JITOSOL' ? selected.symbol : 'SOL'
             } / USD`}
             options={tokenList
@@ -89,6 +92,7 @@ export default function TradingChartHeader({
               .map((token) => {
                 return {
                   title: `${
+                    token.symbol === 'WBTC' ? 'BTC' : 
                     token.symbol !== 'JITOSOL' ? token.symbol : 'SOL'
                   } / USD`,
                 };
@@ -100,7 +104,8 @@ export default function TradingChartHeader({
               const token = tokenList.find(
                 (t) =>
                   t.symbol === selectedTokenSymbol ||
-                  (t.symbol === 'JITOSOL' && selectedTokenSymbol === 'SOL'),
+                  (t.symbol === 'JITOSOL' && selectedTokenSymbol === 'SOL') ||
+                  (t.symbol === 'WBTC' && selectedTokenSymbol === 'BTC'),
               )!;
 
               if (!token) return;
@@ -111,10 +116,11 @@ export default function TradingChartHeader({
           />
         </div>
 
-        <div className="flex w-full p-3 sm:p-0 flex-row gap-3 justify-between sm:justify-end sm:gap-12 items-center sm:pr-5">
+        <div className="flex w-full p-1 sm:p-0 flex-row gap-2 justify-between sm:justify-end sm:gap-6 items-center sm:pr-5"> {}
           <FormatNumber
             nb={
               streamingTokenPrices[
+                selected.symbol === 'WBTC' ? 'BTC' : 
                 selected.symbol !== 'JITOSOL' ? selected.symbol : 'SOL'
               ]
             }
@@ -123,35 +129,66 @@ export default function TradingChartHeader({
             className={twMerge('text-lg font-bold', tokenColor)}
           />
 
-          <div className="flex flex-row gap-3 sm:gap-6">
-            <div className="flex flex-col p-1 rounded-full flex-wrap">
-              <span className="text-xs sm:text-sm text-txtfade text-right">
+          <div className="flex flex-row gap-0 sm:gap-1">
+            <div className="flex items-center p-1 rounded-full flex-wrap">
+              <span className="font-mono text-xs sm:text-xs text-txtfade text-right"> {}
                 24h Change
               </span>
-
               <span
                 className={twMerge(
-                  'font-mono text-sm',
+                  'font-mono text-xs sm:text-xs ml-1', // Adjusted to text-xs
                   stats && stats[selected.symbol].dailyChange > 0
                     ? 'text-green'
                     : 'text-red',
                 )}
               >
                 {stats
-                  ? `${formatNumber(stats[selected.symbol].dailyChange, 2)}%`
+                  ? `${(stats[selected.symbol].dailyChange).toFixed(2)}%` // Manually format to 2 decimal places
                   : '-'}
               </span>
             </div>
 
-            <div className="flex flex-col p-1 rounded-full flex-wrap">
-              <span className="text-xs sm:text-sm text-txtfade text-right">
+            <div className="flex items-center p-1 rounded-full flex-wrap">
+              <span className="font-mono text-xs sm:text-xs text-txtfade text-right"> {}
                 24h Volume
               </span>
+              <span className="font-mono text-xs sm:text-xs ml-1"> {}
+                <FormatNumber
+                  nb={stats?.[selected.symbol].dailyVolume}
+                  format="currency"
+                  isAbbreviate={true}
+                  isDecimalDimmed={false}
+                  className="font-mono text-xs" // Ensure smaller font
+                />
+              </span>
+            </div>
 
-              <FormatNumber
-                nb={stats?.[selected.symbol].dailyVolume}
-                format="currency"
-              />
+            {/* New 24h High */}
+            <div className="flex items-center p-1 rounded-full flex-wrap">
+              <span className="font-mono text-xs sm:text-xs text-txtfade text-right">
+                High
+              </span>
+              <span className="font-mono text-xs sm:text-xs ml-1">
+                <FormatNumber
+                  nb={stats?.[selected.symbol].lastDayHigh} // Assuming high is available in stats
+                  format="currency"
+                  className="font-mono text-xxs"
+                />
+              </span>
+            </div>
+
+            {/* New 24h Low */}
+            <div className="flex items-center p-1 rounded-full flex-wrap">
+              <span className="font-mono text-xs sm:text-xs text-txtfade text-right">
+                Low
+              </span>
+              <span className="font-mono text-xs sm:text-xs ml-1">
+                <FormatNumber
+                  nb={stats?.[selected.symbol].lastDayLow} // Assuming low is available in stats
+                  format="currency"
+                  className="font-mono text-xxs"
+                />
+              </span>
             </div>
           </div>
         </div>

--- a/src/hooks/useDailyStats.ts
+++ b/src/hooks/useDailyStats.ts
@@ -7,6 +7,8 @@ export interface Stats {
   currentPrice: number;
   dailyChange: number;
   dailyVolume: number;
+  lastDayHigh: number;
+  lastDayLow: number;
 }
 
 type FetchedData = {
@@ -22,37 +24,67 @@ export default function useDailyStats() {
 
   const loadStats = useCallback(async () => {
     try {
-      const response = await fetch(
-        `https://api.coingecko.com/api/v3/simple/price?ids=${window.adrena.client.tokens
-          .map((token) => token.coingeckoId)
-          .filter((coingeckoId) => !!coingeckoId)
-          .join(
-            ',',
-          )}&vs_currencies=USD&include_24hr_vol=true&include_24hr_change=true`,
+      const tokenIds = window.adrena.client.tokens
+        .map((token) => token.coingeckoId)
+        .filter((coingeckoId) => !!coingeckoId)
+        .join(',');
+
+      // Fetch price data
+      const priceResponse = await fetch(
+        `https://api.coingecko.com/api/v3/simple/price?ids=${tokenIds}&vs_currencies=USD&include_24hr_vol=true&include_24hr_change=true&usd_24h_high=true&usd_24h_low=true`
       );
 
-      const data: FetchedData = await response.json();
+      // Debugging: Check response status
+      console.log('Price Response Status:', priceResponse.status);
+
+      if (!priceResponse.ok) {
+        throw new Error(`Price fetch error: ${priceResponse.statusText}`);
+      }
+
+      const data: FetchedData = await priceResponse.json();
+
+      // Fetch OHLC data for each token
+      const ohlcPromises = window.adrena.client.tokens.map(async (token) => {
+        if (!token.coingeckoId) return null;
+
+        const ohlcResponse = await fetch(
+          `https://api.coingecko.com/api/v3/coins/${token.coingeckoId}/ohlc?vs_currency=usd&days=1`
+        );
+
+        if (!ohlcResponse.ok) {
+          console.error(`OHLC fetch error for ${token.symbol}: ${ohlcResponse.statusText}`);
+          return null;
+        }
+
+        return ohlcResponse.json();
+      });
+
+      const ohlcDataArray = await Promise.all(ohlcPromises);
 
       setStats(
-        window.adrena.client.tokens.reduce((acc, token) => {
-          if (!token.coingeckoId) return acc;
+        window.adrena.client.tokens.reduce((acc, token, index) => {
+          if (!token.coingeckoId || !ohlcDataArray[index]) return acc;
 
           const { usd, usd_24h_change, usd_24h_vol } = data[token.coingeckoId];
+          const ohlcData = ohlcDataArray[index];
+          const lastDayHigh = ohlcData[0][2]; // High price from OHLC data
+          const lastDayLow = ohlcData[0][3];  // Low price from OHLC data
 
           return {
             ...acc,
-
             [token.symbol]: {
               token,
               currentPrice: usd,
               dailyChange: usd_24h_change,
               dailyVolume: usd_24h_vol,
+              lastDayHigh,
+              lastDayLow,
             },
           };
         }, {} as Record<string, Stats>),
       );
     } catch (err) {
-      console.log('Ignore coingecko api error', err);
+      console.error('Error loading stats:', err);
     }
   }, []);
 

--- a/src/pages/trade/index.tsx
+++ b/src/pages/trade/index.tsx
@@ -261,7 +261,6 @@ export default function Trade({
           <div className="min-h-[24em] max-h-[28em] grow shrink-1 flex max-w-full">
             {/* Display trading chart for appropriate token */}
             {tokenA && tokenB ? (
-              <>
                 <TradingChart
                   token={
                     selectedAction === 'short' || selectedAction === 'long'
@@ -272,7 +271,6 @@ export default function Trade({
                   }
                   positions={positions}
                 />
-              </>
             ) : null}
           </div>
         </div>

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -123,17 +123,17 @@ export function formatPriceInfo(
   )}`;
 }
 
-export function formatNumberShort(nb: number | string): string {
+export function formatNumberShort(nb: number | string, maxDecimals = 2): string { // Added maxDecimals parameter
   if (typeof nb === 'string') {
     nb = Number(nb);
   }
-  if (nb < 1_000) return nb.toString();
+  if (nb < 1_000) return nb.toFixed(maxDecimals).toString();
 
-  if (nb < 1_000_000) return `${(nb / 1_000).toFixed(1)}K`;
+  if (nb < 1_000_000) return `${(nb / 1_000).toFixed(maxDecimals)}K`; // Use maxDecimals
 
-  if (nb < 1_000_000_000) return `${(nb / 1_000_000).toFixed(1)}M`;
+  if (nb < 1_000_000_000) return `${(nb / 1_000_000).toFixed(maxDecimals)}M`; // Use maxDecimals
 
-  return `${(nb / 1_000_000_000).toFixed(1)}B`;
+  return `${(nb / 1_000_000_000).toFixed(maxDecimals)}B`; // Use maxDecimals
 }
 
 export function formatPercentage(

--- a/yarn.lock
+++ b/yarn.lock
@@ -454,7 +454,7 @@
     jsbi "^3.1.5"
     sha.js "^2.4.11"
 
-"@noble/curves@^1.0.0", "@noble/curves@^1.4.2":
+"@noble/curves@^1.0.0", "@noble/curves@^1.1.0", "@noble/curves@^1.4.2":
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.6.0.tgz#be5296ebcd5a1730fccea4786d420f87abfeb40b"
   integrity sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==
@@ -640,6 +640,13 @@
     "@solana/web3.js" "^1.90.0"
     bs58 "^5.0.0"
     jito-ts "^3.0.1"
+
+"@react-native-async-storage/async-storage@^1.17.7":
+  version "1.24.0"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz#888efbc62a26f7d9464b32f4d3027b7f2771999b"
+  integrity sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==
+  dependencies:
+    merge-options "^3.0.4"
 
 "@reduxjs/toolkit@^1.9.3":
   version "1.9.3"
@@ -870,6 +877,37 @@
   resolved "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz"
   integrity sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==
 
+"@solana-mobile/mobile-wallet-adapter-protocol-web3js@^2.1.2":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@solana-mobile/mobile-wallet-adapter-protocol-web3js/-/mobile-wallet-adapter-protocol-web3js-2.1.3.tgz#34da335bc69b6fb0abeadee3f0672841d4f9d688"
+  integrity sha512-IEvPzp4m39sWTS3gybbVfk1WQ5Bx9TrGlthtRlVw1BJPvjbmT6lTcnndgXp7HmMkz5e6cc8fwJWp3EKx5upAug==
+  dependencies:
+    "@solana-mobile/mobile-wallet-adapter-protocol" "^2.1.2"
+    bs58 "^5.0.0"
+    js-base64 "^3.7.5"
+
+"@solana-mobile/mobile-wallet-adapter-protocol@^2.1.2":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@solana-mobile/mobile-wallet-adapter-protocol/-/mobile-wallet-adapter-protocol-2.1.3.tgz#6c87c98f7afec698e14f42726a8b7a161d9e0c78"
+  integrity sha512-rj1/cSQVjPYdQjHsJDxmlpgRjI9jly/0Md3bEeqCan2sLXPf5F6+TiVlAg9+Hxg+uVWd1peUrepFUdOykbklSw==
+  dependencies:
+    "@solana/wallet-standard" "^1.1.2"
+    "@solana/wallet-standard-util" "^1.1.1"
+    "@wallet-standard/core" "^1.0.3"
+    js-base64 "^3.7.5"
+
+"@solana-mobile/wallet-adapter-mobile@^2.0.0":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@solana-mobile/wallet-adapter-mobile/-/wallet-adapter-mobile-2.1.3.tgz#62892131016cb6128922947db8702993a41e4f71"
+  integrity sha512-V9gxV7/F1BLode6I+j134kFvQv1mnF0OlN+tYPHEmJOcH4caDfH6rlJy7t9Pktkl9ZEVTO9kT8K19Y4MRl6nxg==
+  dependencies:
+    "@solana-mobile/mobile-wallet-adapter-protocol-web3js" "^2.1.2"
+    "@solana/wallet-adapter-base" "^0.9.23"
+    "@solana/wallet-standard-features" "^1.2.0"
+    js-base64 "^3.7.5"
+  optionalDependencies:
+    "@react-native-async-storage/async-storage" "^1.17.7"
+
 "@solana/buffer-layout-utils@^0.2.0":
   version "0.2.0"
   resolved "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz"
@@ -923,6 +961,16 @@
   integrity sha512-xbLEZPGSJFvgTeldG9D55evhl7QK/3e/F7vhvcA97mEt1eieTgeKMnGlmmjs3yivI3/gtZNZeSk1XZLnhKcQvw==
   dependencies:
     "@solana/wallet-standard-features" "^1.0.1"
+    "@wallet-standard/base" "^1.0.1"
+    "@wallet-standard/features" "^1.0.3"
+    eventemitter3 "^4.0.7"
+
+"@solana/wallet-adapter-base@^0.9.23":
+  version "0.9.23"
+  resolved "https://registry.yarnpkg.com/@solana/wallet-adapter-base/-/wallet-adapter-base-0.9.23.tgz#3b17c28afd44e173f44f658bf9700fd637e12a11"
+  integrity sha512-apqMuYwFp1jFi55NxDfvXUX2x1T0Zh07MxhZ/nCCTGys5raSfYUh82zen2BLv8BSDj/JxZ2P/s7jrQZGrX8uAw==
+  dependencies:
+    "@solana/wallet-standard-features" "^1.1.0"
     "@wallet-standard/base" "^1.0.1"
     "@wallet-standard/features" "^1.0.3"
     eventemitter3 "^4.0.7"
@@ -1112,6 +1160,15 @@
   dependencies:
     "@solana/wallet-adapter-base" "^0.9.22"
 
+"@solana/wallet-adapter-react@^0.15.35":
+  version "0.15.35"
+  resolved "https://registry.yarnpkg.com/@solana/wallet-adapter-react/-/wallet-adapter-react-0.15.35.tgz#0d42e6774c0d55f3782d3eb5edb6ac9888858b08"
+  integrity sha512-i4hc/gNLTYNLMEt2LS+4lrrc0QAwa5SU2PtYMnZ2A3rsoKF5m1bv1h6cjLj2KBry4/zRGEBoqkiMOC5zHkLnRQ==
+  dependencies:
+    "@solana-mobile/wallet-adapter-mobile" "^2.0.0"
+    "@solana/wallet-adapter-base" "^0.9.23"
+    "@solana/wallet-standard-wallet-adapter-react" "^1.1.0"
+
 "@solana/wallet-adapter-safepal@^0.5.17":
   version "0.5.17"
   resolved "https://registry.npmjs.org/@solana/wallet-adapter-safepal/-/wallet-adapter-safepal-0.5.17.tgz"
@@ -1293,6 +1350,22 @@
   dependencies:
     "@solana/wallet-adapter-base" "^0.9.22"
 
+"@solana/wallet-standard-chains@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@solana/wallet-standard-chains/-/wallet-standard-chains-1.1.0.tgz#459b297e71b0d9c1196c11a0578b38c85998be7d"
+  integrity sha512-IRJHf94UZM8AaRRmY18d34xCJiVPJej1XVwXiTjihHnmwD0cxdQbc/CKjrawyqFyQAKJx7raE5g9mnJsAdspTg==
+  dependencies:
+    "@wallet-standard/base" "^1.0.1"
+
+"@solana/wallet-standard-core@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@solana/wallet-standard-core/-/wallet-standard-core-1.1.1.tgz#7187c085dcee38719902217a7ecdd1bf3f27afa3"
+  integrity sha512-DoQ5Ryly4GAZtxRUmW2rIWrgNvTYVCWrFCFFjZI5s4zu2QNsP7sHZUax3kc1GbmFLXNL1FWRZlPOXRs6e0ZEng==
+  dependencies:
+    "@solana/wallet-standard-chains" "^1.1.0"
+    "@solana/wallet-standard-features" "^1.2.0"
+    "@solana/wallet-standard-util" "^1.1.1"
+
 "@solana/wallet-standard-features@^1.0.1":
   version "1.0.1"
   resolved "https://registry.npmjs.org/@solana/wallet-standard-features/-/wallet-standard-features-1.0.1.tgz"
@@ -1300,6 +1373,62 @@
   dependencies:
     "@wallet-standard/base" "^1.0.1"
     "@wallet-standard/features" "^1.0.3"
+
+"@solana/wallet-standard-features@^1.1.0", "@solana/wallet-standard-features@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@solana/wallet-standard-features/-/wallet-standard-features-1.2.0.tgz#be8b3824abf5ebcfeaa7298445bf53f76a27c935"
+  integrity sha512-tUd9srDLkRpe1BYg7we+c4UhRQkq+XQWswsr/L1xfGmoRDF47BPSXf4zE7ZU2GRBGvxtGt7lwJVAufQyQYhxTQ==
+  dependencies:
+    "@wallet-standard/base" "^1.0.1"
+    "@wallet-standard/features" "^1.0.3"
+
+"@solana/wallet-standard-util@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@solana/wallet-standard-util/-/wallet-standard-util-1.1.1.tgz#f645fdd8b7d3c553a3b59aa19c25c51a1badce66"
+  integrity sha512-dPObl4ntmfOc0VAGGyyFvrqhL8UkHXmVsgbj0K9RcznKV4KB3MgjGwzo8CTSX5El5lkb0rDeEzFqvToJXRz3dw==
+  dependencies:
+    "@noble/curves" "^1.1.0"
+    "@solana/wallet-standard-chains" "^1.1.0"
+    "@solana/wallet-standard-features" "^1.2.0"
+
+"@solana/wallet-standard-wallet-adapter-base@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@solana/wallet-standard-wallet-adapter-base/-/wallet-standard-wallet-adapter-base-1.1.2.tgz#f030f412cd16b06e95c6da5548a03113319d3620"
+  integrity sha512-DqhzYbgh3disHMgcz6Du7fmpG29BYVapNEEiL+JoVMa+bU9d4P1wfwXUNyJyRpGGNXtwhyZjIk2umWbe5ZBNaQ==
+  dependencies:
+    "@solana/wallet-adapter-base" "^0.9.23"
+    "@solana/wallet-standard-chains" "^1.1.0"
+    "@solana/wallet-standard-features" "^1.2.0"
+    "@solana/wallet-standard-util" "^1.1.1"
+    "@wallet-standard/app" "^1.0.1"
+    "@wallet-standard/base" "^1.0.1"
+    "@wallet-standard/features" "^1.0.3"
+    "@wallet-standard/wallet" "^1.0.1"
+
+"@solana/wallet-standard-wallet-adapter-react@^1.1.0", "@solana/wallet-standard-wallet-adapter-react@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@solana/wallet-standard-wallet-adapter-react/-/wallet-standard-wallet-adapter-react-1.1.2.tgz#a7bc71786e8f891d2dd83f7de30db4708767a56a"
+  integrity sha512-bN6W4QkzenyjUoUz3sC5PAed+z29icGtPh9VSmLl1ZrRO7NbFB49a8uwUUVXNxhL/ZbMsyVKhb9bNj47/p8uhQ==
+  dependencies:
+    "@solana/wallet-standard-wallet-adapter-base" "^1.1.2"
+    "@wallet-standard/app" "^1.0.1"
+    "@wallet-standard/base" "^1.0.1"
+
+"@solana/wallet-standard-wallet-adapter@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@solana/wallet-standard-wallet-adapter/-/wallet-standard-wallet-adapter-1.1.2.tgz#a9ff9e4d5c379e4f38c03a2b69c9a221904181b6"
+  integrity sha512-lCwoA+vhPfmvjcmJOhSRV94wouVWTfJv1Z7eeULAe+GodCeKA/0T9/uBYgXHUxQjLHd7o8LpLYIkfm+xjA5sMA==
+  dependencies:
+    "@solana/wallet-standard-wallet-adapter-base" "^1.1.2"
+    "@solana/wallet-standard-wallet-adapter-react" "^1.1.2"
+
+"@solana/wallet-standard@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@solana/wallet-standard/-/wallet-standard-1.1.2.tgz#b68e38db863f6945979fe278f2cecc2e21f84c2d"
+  integrity sha512-o7wk+zr5/QgyE393cGRC04K1hacR4EkBu3MB925ddaLvCVaXjwr2asgdviGzN9PEm3FiEJp3sMmMKYHFnwOITQ==
+  dependencies:
+    "@solana/wallet-standard-core" "^1.1.1"
+    "@solana/wallet-standard-wallet-adapter" "^1.1.2"
 
 "@solana/web3.js@^1.32.0", "@solana/web3.js@^1.36.0", "@solana/web3.js@^1.44.3", "@solana/web3.js@^1.63.1", "@solana/web3.js@^1.68.0", "@solana/web3.js@^1.73.3":
   version "1.73.3"
@@ -1910,15 +2039,39 @@
   dependencies:
     server-only "^0.0.1"
 
+"@wallet-standard/app@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@wallet-standard/app/-/app-1.0.1.tgz#f83c3ae887f7fb52497a7b259bba734ae10a2994"
+  integrity sha512-LnLYq2Vy2guTZ8GQKKSXQK3+FRGPil75XEdkZqE6fiLixJhZJoJa5hT7lXxwe0ykVTt9LEThdTbOpT7KadS26Q==
+  dependencies:
+    "@wallet-standard/base" "^1.0.1"
+
 "@wallet-standard/base@^1.0.1":
   version "1.0.1"
   resolved "https://registry.npmjs.org/@wallet-standard/base/-/base-1.0.1.tgz"
   integrity sha512-1To3ekMfzhYxe0Yhkpri+Fedq0SYcfrOfJi3vbLjMwF2qiKPjTGLwZkf2C9ftdQmxES+hmxhBzTwF4KgcOwf8w==
 
+"@wallet-standard/core@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@wallet-standard/core/-/core-1.0.3.tgz#3b6743e207ca4e1e725ae20f1838b400fb0694ff"
+  integrity sha512-Jb33IIjC1wM1HoKkYD7xQ6d6PZ8EmMZvyc8R7dFgX66n/xkvksVTW04g9yLvQXrLFbcIjHrCxW6TXMhvpsAAzg==
+  dependencies:
+    "@wallet-standard/app" "^1.0.1"
+    "@wallet-standard/base" "^1.0.1"
+    "@wallet-standard/features" "^1.0.3"
+    "@wallet-standard/wallet" "^1.0.1"
+
 "@wallet-standard/features@^1.0.3":
   version "1.0.3"
   resolved "https://registry.npmjs.org/@wallet-standard/features/-/features-1.0.3.tgz"
   integrity sha512-m8475I6W5LTatTZuUz5JJNK42wFRgkJTB0I9tkruMwfqBF2UN2eomkYNVf9RbrsROelCRzSFmugqjKZBFaubsA==
+  dependencies:
+    "@wallet-standard/base" "^1.0.1"
+
+"@wallet-standard/wallet@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@wallet-standard/wallet/-/wallet-1.0.1.tgz#95438941a2a1ee12a794444357b59d53e19b374c"
+  integrity sha512-qkhJeuQU2afQTZ02yMZE5SFc91Fo3hyFjFkpQglHudENNyiSG0oUKcIjky8X32xVSaumgTZSQUAzpXnCTWHzKQ==
   dependencies:
     "@wallet-standard/base" "^1.0.1"
 
@@ -4821,6 +4974,11 @@ jito-ts@^3.0.1:
     node-fetch "^2.6.7"
     superstruct "^1.0.3"
 
+js-base64@^3.7.5:
+  version "3.7.7"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.7.tgz#e51b84bf78fbf5702b9541e2cb7bfcb893b43e79"
+  integrity sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==
+
 js-sdsl@^4.1.4:
   version "4.3.0"
   resolved "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz"
@@ -5093,6 +5251,13 @@ md5.js@^1.3.4:
     hash-base "^3.0.0"
     inherits "^2.0.1"
     safe-buffer "^5.1.2"
+
+merge-options@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-3.0.4.tgz#84709c2aa2a4b24c1981f66c179fe5565cc6dbb7"
+  integrity sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==
+  dependencies:
+    is-plain-obj "^2.1.0"
 
 merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"


### PR DESCRIPTION
Before 
![Screenshot 2024-09-24 at 8 38 45 AM](https://github.com/user-attachments/assets/f863daf3-19c0-4019-ba41-2ad9624f3807)


After 
![Screenshot 2024-09-24 at 1 43 31 PM](https://github.com/user-attachments/assets/afd378aa-89d1-42cb-8242-2bfbc1a721d0)


- Change SL/TP lines colours to blue (from orange)
- Being able to click SL/TP prices in the position to open the TP/SL page
- Being able to click the Lie price to add open the Add collateral popup
- Add a hover effect to these values for more explicit UI/UX
- Change liquidation line to orange
- Update the TP/SL drawing logic to not redraw constantly and pile up
- Change SL and TP labels to be shorter
- Remove the price display in SL and TP labels
- Increase chart min size to 600 px
- Save chart resolution locally
- - reduced header padding making it more compact
- Made header value display on single line + compact display + change colours
- Added high low
- + unrecorded stuff