### PR TITLE
fix/stake-overview-pending-rewards-display

### DIFF
--- a/src/components/pages/stake/StakeOverview.tsx
+++ b/src/components/pages/stake/StakeOverview.tsx
@@ -213,7 +213,7 @@ export default function StakeOverview({
 
                   {pendingGenesisAdxRewards !== 0 ? (
                     <div className="flex items-center justify-center text-xs mt-1">
-                      <span className="text-blue mr-1">
+                      <span className="mr-1">
                         {!isMobile ? 'Genesis Bonus' : null}
                         <Tippy
                           content={
@@ -240,9 +240,8 @@ export default function StakeOverview({
                       <FormatNumber
                         nb={pendingGenesisAdxRewards}
                         isDecimalDimmed={false}
-                        className="text-blue"
                       />
-                      <span className="text-blue ml-1 mt-[2px]">ADX</span>
+                      <span className="ml-1 mt-[2px]">ADX</span>
                     </div>
                   ) : null}
                 </div>

--- a/src/components/pages/stake/StakeOverview.tsx
+++ b/src/components/pages/stake/StakeOverview.tsx
@@ -77,7 +77,7 @@ export default function StakeOverview({
         <div className="flex flex-col sm:flex-row items-center h-full w-full bg-gradient-to-br from-[#07111A] to-[#0B1722] border rounded-lg shadow-lg">
           <div
             className={twMerge(
-              'flex items-center w-full sm:w-auto sm:min-w-[200px] rounded-t-lg sm:rounded-r-none sm:rounded-l-lg p-3 sm:h-full flex-none border-r',
+              'flex items-center w-full sm:w-auto sm:min-w-[200px] rounded-t-lg sm:rounded-r-none sm:rounded-l-lg p-3 sm:h-full flex-none sm:border-r',
               isALP ? 'bg-[#130AAA]' : 'bg-[#991B1B]',
             )}
           >
@@ -178,7 +178,7 @@ export default function StakeOverview({
             />
           </div>
 
-          <div className="flex flex-col border bg-secondary rounded-xl shadow-lg">
+          <div className="flex flex-col border bg-secondary rounded-xl shadow-lg overflow-hidden">
             <div
               className={twMerge(
                 'flex justify-between items-center relative w-full overflow-hidden pt-4 pb-4',


### PR DESCRIPTION
Staring at the stake overview page too much. Really liked the new pending rewards section. Some very minor tweaks to improve it:

- Added `overflow-hidden` on the div to round out the usdc and adx and white text for readability

Orginial:
![image](https://github.com/user-attachments/assets/6a979916-ae54-41d0-b42a-fb00a88af7d5)

Changes:
![image](https://github.com/user-attachments/assets/c066a846-737c-468a-8116-d929e636f556)


- Removed extra right border on mobile display (added `sm:`)to fill out the area better.

Original:
![image](https://github.com/user-attachments/assets/95004927-8863-41f1-870d-945a6c538f6f)


Changes:
![image](https://github.com/user-attachments/assets/852ecae1-bf33-4d2f-be70-79a8156eadcd)
