### PR TITLE
contrib: fix streamingTokenPricesReducer should not update state unnecessarily

### DIFF
--- a/src/reducers/streamingTokenPricesReducer.ts
+++ b/src/reducers/streamingTokenPricesReducer.ts
@@ -11,11 +11,19 @@ export default function streamingTokenPricesReducer(
   action: StreamingTokenPricesAction,
 ) {
   switch (action.type) {
-    case 'setStreamingTokenPrice':
+    case 'setStreamingTokenPrice': {
+      // Return previous state, do not unnecessarily update state
+      // if the new price is the same as the previous price.
+      // An upgrade of the Redux toolchain would help removing this boilerplate.
+      if (state[action.payload.tokenSymbol] === action.payload.price) {
+        return state;
+      }
+
       return {
         ...state,
         [action.payload.tokenSymbol]: action.payload.price,
       };
+    }
     default:
       return state;
   }


### PR DESCRIPTION
Return previous state, do not unnecessarily update state if the new price is the same as the previous price.

An upgrade of the Redux toolchain would help removing this boilerplate.