### PR TITLE
contrib: cleanup daily stats fetching from coingecko & usage in TradingChartHeader

### DIFF
--- a/src/components/pages/trading/TradingChartHeader/TradingChartHeader.tsx
+++ b/src/components/pages/trading/TradingChartHeader/TradingChartHeader.tsx
@@ -56,6 +56,11 @@ export default function TradingChartHeader({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [streamingTokenPrices]);
 
+  const dailyChange = stats?.[selected.symbol]?.dailyChange ?? null;
+  const dailyVolume = stats?.[selected.symbol]?.dailyVolume ?? null;
+  const lastDayHigh = stats?.[selected.symbol]?.lastDayHigh ?? null;
+  const lastDayLow = stats?.[selected.symbol]?.lastDayLow ?? null;
+
   return (
     <>
       <Head>
@@ -120,13 +125,15 @@ export default function TradingChartHeader({
               <span
                 className={twMerge(
                   'font-mono text-xs sm:text-xxs ml-1', // Adjusted to text-xs
-                  stats && stats[selected.symbol].dailyChange > 0
-                    ? 'text-green'
-                    : 'text-red',
+                  dailyChange
+                    ? dailyChange > 0
+                      ? 'text-green'
+                      : 'text-red'
+                    : 'text-white',
                 )}
               >
-                {stats
-                  ? `${stats[selected.symbol].dailyChange.toFixed(2)}%` // Manually format to 2 decimal places
+                {dailyChange
+                  ? `${dailyChange.toFixed(2)}%` // Manually format to 2 decimal places
                   : '-'}
               </span>
             </div>
@@ -137,7 +144,7 @@ export default function TradingChartHeader({
               </span>
               <span className="font-mono text-xs sm:text-xxs ml-1">
                 <FormatNumber
-                  nb={stats?.[selected.symbol].dailyVolume}
+                  nb={dailyVolume}
                   format="currency"
                   isAbbreviate={true}
                   isDecimalDimmed={false}
@@ -152,7 +159,7 @@ export default function TradingChartHeader({
               </span>
               <span className="font-mono text-xs sm:text-xxs ml-1">
                 <FormatNumber
-                  nb={stats?.[selected.symbol].lastDayHigh} // Assuming high is available in stats
+                  nb={lastDayHigh} // Assuming high is available in stats
                   format="currency"
                   className="font-mono text-xxs"
                 />
@@ -165,7 +172,7 @@ export default function TradingChartHeader({
               </span>
               <span className="font-mono text-xxs sm:text-xs ml-1">
                 <FormatNumber
-                  nb={stats?.[selected.symbol].lastDayLow} // Assuming low is available in stats
+                  nb={lastDayLow} // Assuming low is available in stats
                   format="currency"
                   className="font-mono text-xxs"
                 />

--- a/src/hooks/useDailyStats.ts
+++ b/src/hooks/useDailyStats.ts
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useState } from 'react';
 // All fields are nullable because they're aggregated from multiple
 // independent HTTP calls, which may fail, see below note about rate-limiting.
 type TokenStats = {
-  currentPrice: number | null;
   dailyChange: number | null;
   dailyVolume: number | null;
   lastDayHigh: number | null;
@@ -16,7 +15,6 @@ type DailyStats = {
 
 type CoingeckoPriceData = {
   [coingeckoId: string]: {
-    usd: number;
     usd_24h_vol: number;
     usd_24h_change: number;
   };
@@ -109,7 +107,6 @@ export default function useDailyStats() {
           : null;
 
       const tokenStats: TokenStats = {
-        currentPrice: tokenPriceData?.usd ?? null,
         dailyChange: tokenPriceData?.usd_24h_change ?? null,
         dailyVolume: tokenPriceData?.usd_24h_vol ?? null,
         lastDayHigh: ohlcData && Math.max(...ohlcData.map((ohlc) => ohlc[2])),

--- a/src/hooks/useDailyStats.ts
+++ b/src/hooks/useDailyStats.ts
@@ -1,90 +1,128 @@
 import { useCallback, useEffect, useState } from 'react';
 
-import { Token } from '@/types';
+// All fields are nullable because they're aggregated from multiple
+// independent HTTP calls, which may fail, see below note about rate-limiting.
+type TokenStats = {
+  currentPrice: number | null;
+  dailyChange: number | null;
+  dailyVolume: number | null;
+  lastDayHigh: number | null;
+  lastDayLow: number | null;
+};
 
-export interface Stats {
-  token: Token;
-  currentPrice: number;
-  dailyChange: number;
-  dailyVolume: number;
-  lastDayHigh: number;
-  lastDayLow: number;
-}
+type DailyStats = {
+  [tokenSymbol: string]: TokenStats;
+};
 
-type FetchedData = {
-  [tokenSymbol: string]: {
+type CoingeckoPriceData = {
+  [coingeckoId: string]: {
     usd: number;
     usd_24h_vol: number;
     usd_24h_change: number;
   };
 };
 
-type OHLC = [number, number, number, number, number]; // [timestamp, open, high, low, close]
+// Array<[timestamp, open, high, low, close]>
+type CoingeckoOHLCData = Array<[number, number, number, number, number]>;
+
+// FIXME: This is ideally proxied through a HTTP API **with HTTP Cache**
+//        & fetched from the server in SSR when directly accessing the Trading view.
+//        This will allow it to be more resilient & performant.
+//        The free Coingecko API is limited to ~30 API calls per minute per ip.
+//        - https://docs.coingecko.com/reference/common-errors-rate-limit
+const COINGECKO_BASE_URL = new URL('https://api.coingecko.com/');
+
+const COINGECKO_PRICE_URL_PARAMS = new URLSearchParams({
+  vs_currencies: 'USD',
+  include_24hr_vol: 'true',
+  include_24hr_change: 'true',
+});
+
+const COINGECKO_PRICE_API_URL = new URL(
+  '/api/v3/simple/price',
+  COINGECKO_BASE_URL,
+);
+
+const COINGECKO_OHLC_API_URL_PARAMS = new URLSearchParams({
+  vs_currency: 'usd',
+  days: '1',
+});
+const getCoingeckoOHLCApiURL = (coingeckoId: string) =>
+  new URL(
+    `/api/v3/coins/${coingeckoId}/ohlc?${COINGECKO_OHLC_API_URL_PARAMS}`,
+    COINGECKO_BASE_URL,
+  );
 
 export default function useDailyStats() {
-  const [stats, setStats] = useState<null | Record<string, Stats>>(null);
+  const [stats, setStats] = useState<null | DailyStats>(null);
 
   const loadStats = useCallback(async () => {
-    try {
-      const tokenIds = window.adrena.client.tokens
-        .map((token) => token.coingeckoId)
-        .filter((coingeckoId) => !!coingeckoId)
-        .join(',');
+    const tokenCoingeckoIds = window.adrena.client.tokens
+      .map((token) => token.coingeckoId)
+      .filter(Boolean) as Array<string>;
 
-      // Fetch price data
-      const priceResponse = await fetch(
-        `https://api.coingecko.com/api/v3/simple/price?ids=${tokenIds}&vs_currencies=USD&include_24hr_vol=true&include_24hr_change=true`
-      );
-
-      if (!priceResponse.ok) {
-        throw new Error(`Price fetch error: ${priceResponse.statusText}`);
-      }
-
-      const data: FetchedData = await priceResponse.json();
-
-      // Fetch OHLC data for each token
-      const ohlcPromises = window.adrena.client.tokens.map(async (token) => {
-        if (!token.coingeckoId) return null;
-
-        const ohlcResponse = await fetch(
-          `https://api.coingecko.com/api/v3/coins/${token.coingeckoId}/ohlc?vs_currency=usd&days=1`
-        );
-
-        if (!ohlcResponse.ok) {
-          console.error(`OHLC fetch error for ${token.symbol}: ${ohlcResponse.statusText}`);
+    COINGECKO_PRICE_URL_PARAMS.set('ids', tokenCoingeckoIds.join(','));
+    const priceApiUrl = `${COINGECKO_PRICE_API_URL}?${COINGECKO_PRICE_URL_PARAMS}`;
+    const priceApiFetchPromise = fetch(priceApiUrl).then(
+      (res): Promise<CoingeckoPriceData> | null => {
+        if (!res.ok) {
+          console.error(`Coingecko OHLC fetch error: ${res.statusText}`);
           return null;
         }
+        return res.json();
+      },
+    );
 
-        return ohlcResponse.json();
-      });
-
-      const ohlcDataArray = await Promise.all(ohlcPromises);
-
-      setStats(
-        window.adrena.client.tokens.reduce((acc, token, index) => {
-          if (!token.coingeckoId || !ohlcDataArray[index]) return acc;
-
-          const { usd, usd_24h_change, usd_24h_vol } = data[token.coingeckoId];
-          const ohlcData = ohlcDataArray[index];
-          const lastDayHigh = Math.max(...ohlcData.map((ohlc: OHLC) => ohlc[2]));
-          const lastDayLow = Math.min(...ohlcData.map((ohlc: OHLC) => ohlc[3])); 
-
-          return {
-            ...acc,
-            [token.symbol]: {
-              token,
-              currentPrice: usd,
-              dailyChange: usd_24h_change,
-              dailyVolume: usd_24h_vol,
-              lastDayHigh,
-              lastDayLow,
-            },
-          };
-        }, {} as Record<string, Stats>),
+    const ohlcApiFetchPromises = tokenCoingeckoIds.map((coingeckoId) => {
+      const ohlcApiUrl = getCoingeckoOHLCApiURL(coingeckoId);
+      return fetch(ohlcApiUrl).then(
+        (res): Promise<CoingeckoOHLCData> | null => {
+          if (!res.ok) {
+            console.error(
+              `Coingecko OHLC fetch error for ${coingeckoId}: ${res.statusText}`,
+            );
+            return null;
+          }
+          return res.json();
+        },
       );
-    } catch (err) {
-      console.error('Error loading stats:', err);
-    }
+    });
+
+    const [priceDataResult, ...ohlcDataResults] = await Promise.allSettled([
+      priceApiFetchPromise,
+      ...ohlcApiFetchPromises,
+    ]);
+
+    const stats = window.adrena.client.tokens.reduce((acc, token, index) => {
+      if (!token.coingeckoId || !ohlcDataResults[index]) return acc;
+
+      const tokenPriceData =
+        priceDataResult.status === 'fulfilled' &&
+        priceDataResult.value &&
+        token.coingeckoId in priceDataResult.value
+          ? priceDataResult.value[token.coingeckoId]
+          : null;
+
+      const ohlcData =
+        ohlcDataResults[index].status === 'fulfilled'
+          ? ohlcDataResults[index].value
+          : null;
+
+      const tokenStats: TokenStats = {
+        currentPrice: tokenPriceData?.usd ?? null,
+        dailyChange: tokenPriceData?.usd_24h_change ?? null,
+        dailyVolume: tokenPriceData?.usd_24h_vol ?? null,
+        lastDayHigh: ohlcData && Math.max(...ohlcData.map((ohlc) => ohlc[2])),
+        lastDayLow: ohlcData && Math.min(...ohlcData.map((ohlc) => ohlc[3])),
+      };
+
+      return {
+        ...acc,
+        [token.symbol]: tokenStats,
+      };
+    }, {} as DailyStats);
+
+    setStats(stats);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
- remove "token" info from useDailyStats local state, unused, unnecessary
- cleanup `useDailyStats` hook
  - cleaner definition of coingecko API endpoints & params
  - cleaner logic to handle all the API calls concurrently & more resilient
  - more precise & accurate typings
- the token price & OHLC data are now fetched concurrently instead of the price retrieval being blocking