### PR TITLE
contrib: optimize (memoize) WalletAdapter component

### DIFF
--- a/src/components/BurgerMenu/BurgerMenu.tsx
+++ b/src/components/BurgerMenu/BurgerMenu.tsx
@@ -184,7 +184,7 @@ export default function BurgerMenu({
 
           <WalletAdapter
             className="w-full"
-            userProfile={userProfile}
+            userProfileNickname={userProfile ? userProfile.nickname : null}
             isIconOnly
           />
 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -6,7 +6,11 @@ import { twMerge } from 'tailwind-merge';
 
 import externalLinkLogo from '@/../public/images/external-link-logo.png';
 import { useSelector } from '@/store/store';
-import { PriorityFeeOption, SolanaExplorerOptions, UserProfileExtended } from '@/types';
+import {
+  PriorityFeeOption,
+  SolanaExplorerOptions,
+  UserProfileExtended,
+} from '@/types';
 import { formatPriceInfo } from '@/utils';
 
 import chevronDownIcon from '../../../public/images/chevron-down.svg';
@@ -192,7 +196,9 @@ export default function Header({
           preferredSolanaExplorer={preferredSolanaExplorer}
         />
 
-        <WalletAdapter userProfile={userProfile} />
+        <WalletAdapter
+          userProfileNickname={userProfile ? userProfile.nickname : null}
+        />
 
         {clusterSwitchEnabled ? (
           <Menu

--- a/src/components/WalletAdapter/WalletAdapter.tsx
+++ b/src/components/WalletAdapter/WalletAdapter.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/actions/walletActions';
 import { walletAdapters } from '@/constant';
 import { useDispatch, useSelector } from '@/store/store';
-import { ImageRef, UserProfileExtended, WalletAdapterName } from '@/types';
+import { ImageRef, WalletAdapterName } from '@/types';
 import { getAbbrevNickname, getAbbrevWalletAddress } from '@/utils';
 
 import backpackLogo from '../../../public/images/backpack.png';
@@ -30,13 +30,13 @@ const WALLET_ICONS = {
   coinbase: coinbaseLogo,
 } as const satisfies Record<WalletAdapterName, ImageRef>;
 
-export default function WalletAdapter({
+function WalletAdapter({
   className,
-  userProfile,
+  userProfileNickname,
   isIconOnly,
 }: {
   className?: string;
-  userProfile: UserProfileExtended | null | false;
+  userProfileNickname: null | string;
   isIconOnly?: boolean;
 }) {
   const dispatch = useDispatch();
@@ -101,8 +101,8 @@ export default function WalletAdapter({
               )}
               title={
                 !isIconOnly
-                  ? userProfile
-                    ? getAbbrevNickname(userProfile.nickname)
+                  ? userProfileNickname
+                    ? getAbbrevNickname(userProfileNickname)
                     : getAbbrevWalletAddress(wallet.walletAddress)
                   : null
               }
@@ -156,3 +156,10 @@ export default function WalletAdapter({
     </div>
   );
 }
+
+// Memoize the WalletAdapter component to avoid unnecessary re-renders
+// caused by re-renders of the parent component.
+// This component is a good candidate for memoization as it now only relies
+// on "scalar" / "primitive-type" / "referentially-stable" / "simple" props.
+// - https://react.dev/reference/react/memo
+export default React.memo(WalletAdapter);


### PR DESCRIPTION
- change `WalletAdapter` component expected props signature:
  - `userProfile: UserProfileExtended | null | false` -> `userProfileNickName: string | null`
  - striving for "simple" prop types allows to use component memoization
  - https://react.dev/reference/react/memo
- enable component memoization of the `WalletAdapter` component
  - prevent unnecessary re-renders caused by a parent component
    - ie: `Header` / `BurgerMenu`
- the same type of optimizations can be applied throughout the app for good impact & minimal changes, as well as improving overall architecture, testability.