### PR TITLE
contrib: optimize useWatchWalletBalances hook with public key caching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "@solana/web3.js": "^1.73.3",
         "@switchboard-xyz/solana.js": "^3.2.5",
         "@tippyjs/react": "^4.2.6",
-        "@triton-one/yellowstone-grpc": "^0.6.0",
         "@vercel/analytics": "^1.3.1",
         "@vercel/og": "^0.6.3",
         "@vercel/speed-insights": "^1.0.14",
@@ -44,6 +43,7 @@
         "react-toastify": "^9.1.3",
         "react-transition-group": "^4.4.5",
         "recharts": "^2.12.7",
+        "reselect": "^4.1.8",
         "tailwind-merge": "^1.10.0",
         "tailwindcss": "^3.2.7"
       },
@@ -7202,15 +7202,6 @@
       },
       "peerDependencies": {
         "@babel/runtime": "7.x"
-      }
-    },
-    "node_modules/@triton-one/yellowstone-grpc": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@triton-one/yellowstone-grpc/-/yellowstone-grpc-0.6.0.tgz",
-      "integrity": "sha512-rgdZM2N3U9/d/QKOI5PP+9rSHUl2oSI5Uwzvuss8y/mtTaHFjbOMpXpQXviIeDkusOa+mef4wLYrbjEZCwTXiw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@grpc/grpc-js": "^1.8.0"
       }
     },
     "node_modules/@types/big.js": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "react-toastify": "^9.1.3",
     "react-transition-group": "^4.4.5",
     "recharts": "^2.12.7",
+    "reselect": "^4.1.8",
     "tailwind-merge": "^1.10.0",
     "tailwindcss": "^3.2.7"
   },

--- a/src/components/RefreshButton/RefreshButton.tsx
+++ b/src/components/RefreshButton/RefreshButton.tsx
@@ -8,7 +8,7 @@ import { addNotification } from '@/utils';
 import refreshIcon from '../../../public/images/refresh.png';
 
 export default function RefreshButton({ className }: { className?: string }) {
-  const { triggerWalletTokenBalancesReload } = useWatchWalletBalance();
+  const triggerWalletTokenBalancesReload = useWatchWalletBalance();
 
   const handleReload = () => {
     triggerWalletTokenBalancesReload();

--- a/src/hooks/useWatchWalletBalance.ts
+++ b/src/hooks/useWatchWalletBalance.ts
@@ -1,26 +1,59 @@
 import { BN } from '@coral-xyz/anchor';
 import { NATIVE_MINT } from '@solana/spl-token';
-import { PublicKey, RpcResponseAndContext, TokenAmount } from '@solana/web3.js';
+import { PublicKey } from '@solana/web3.js';
 import { useCallback, useEffect, useState } from 'react';
 
 import { setWalletTokenBalancesAction } from '@/actions/walletBalancesActions';
 import { SOL_DECIMALS } from '@/constant';
+import { selectWalletPublicKey } from '@/selectors/wallet';
 import { useDispatch, useSelector } from '@/store/store';
 import { TokenSymbol } from '@/types';
 import { findATAAddressSync, nativeToUi } from '@/utils';
 
+const WALLET_TO_ATAS_CACHE = new WeakMap<
+  PublicKey,
+  WeakMap<PublicKey, PublicKey>
+>();
+function getAtaFromCacheOrSet(
+  walletPublicKey: PublicKey,
+  mint: PublicKey,
+): PublicKey {
+  const maybeAtasCacheForPubKey = WALLET_TO_ATAS_CACHE.get(walletPublicKey);
+  if (!maybeAtasCacheForPubKey) {
+    WALLET_TO_ATAS_CACHE.set(walletPublicKey, new WeakMap());
+    return getAtaFromCacheOrSet(walletPublicKey, mint);
+  }
+
+  const maybeAta = maybeAtasCacheForPubKey.get(mint);
+  if (maybeAta) return maybeAta;
+  const ata = findATAAddressSync(walletPublicKey, mint);
+  maybeAtasCacheForPubKey.set(mint, ata);
+  return ata;
+}
+
 // TODO: Make it responsive to wallet token balance change
-export default function useWatchWalletBalance(): {
-  triggerWalletTokenBalancesReload: () => void;
-} {
+// FIXME: This hook is used in multiple places throughout the app,
+//        and isn't viable as a React (effect-based) hook,
+//        as multiple concurrent fetches will happen, triggerred by
+//        multiple consumers.
+//        As instead, this function should be implemented as
+//        Redux Thunk (async) action, populating a store.
+//        This might a good opportunity to use RTK Query or equivalent, to
+//        track the status of the query.
+// NOTE:  Additionally, ATAs, PublicKeys computation are expensive
+//        & should be cached, done here through:
+//        - `WALLET_TO_ATAS_CACHE`
+//        - `useSelector(selectWalletPublicKey)`
+export default function useWatchWalletBalance() {
   const [trickReload, triggerReload] = useState<number>(0);
   const dispatch = useDispatch();
-  const wallet = useSelector((s) => s.walletState.wallet);
+
+  const walletPublicKey = useSelector(selectWalletPublicKey);
 
   const loadWalletBalances = useCallback(async () => {
     const connection = window.adrena.client.connection;
 
-    if (!wallet || !dispatch || !connection) {
+    if (!walletPublicKey || !connection) {
       dispatch(setWalletTokenBalancesAction(null));
       return;
     }
@@ -35,24 +68,15 @@ export default function useWatchWalletBalance(): {
 
     const balances = await Promise.all(
       tokens.map(async ({ mint }) => {
-        const ata = findATAAddressSync(
-          new PublicKey(wallet.walletAddress),
-          mint,
-        );
+        const ata = getAtaFromCacheOrSet(walletPublicKey, mint);
 
         // in case of SOL, consider both SOL in the wallet + WSOL in ATA
         if (mint.equals(NATIVE_MINT)) {
           try {
             const [wsolBalance, solBalance] = await Promise.all([
               // Ignore ATA error if any, consider there are 0 WSOL
-              new Promise((resolve) => {
-                connection
-                  .getTokenAccountBalance(ata)
-                  .then(resolve)
-                  .catch(() => resolve(null));
-              }) as Promise<RpcResponseAndContext<TokenAmount> | null>,
-
-              connection.getBalance(new PublicKey(wallet.walletAddress)),
+              connection.getTokenAccountBalance(ata).catch(() => null),
+              connection.getBalance(walletPublicKey),
             ]);
 
             return (
@@ -84,16 +108,17 @@ export default function useWatchWalletBalance(): {
         }, {} as Record<TokenSymbol, number | null>),
       ),
     );
+    // extra `trickReload` dependency (temporary hack pending refactoring)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [wallet, dispatch, trickReload, window.adrena.client.connection]);
+  }, [walletPublicKey, trickReload, dispatch]);
 
   useEffect(() => {
     loadWalletBalances();
   }, [loadWalletBalances]);
 
-  return {
-    triggerWalletTokenBalancesReload: () => {
-      triggerReload(trickReload + 1);
-    },
-  };
+  const triggerWalletTokenBalancesReload = useCallback(() => {
+    triggerReload((prevState) => prevState + 1);
+  }, []);
+
+  return triggerWalletTokenBalancesReload;
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -69,7 +69,7 @@ export default function App(props: AppProps) {
 
   const preferredSolanaExplorer: SolanaExplorerOptions =
     cookies?.solanaExplorer &&
-      SOLANA_EXPLORERS_OPTIONS.hasOwnProperty(cookies.solanaExplorer)
+    SOLANA_EXPLORERS_OPTIONS.hasOwnProperty(cookies.solanaExplorer)
       ? cookies?.solanaExplorer
       : 'Solana Explorer';
 
@@ -185,7 +185,6 @@ export default function App(props: AppProps) {
 
         <Analytics />
         <SpeedInsights />
-
       </CookiesProvider>
     </Provider>
   );
@@ -237,7 +236,7 @@ function AppComponent({
 
   useWatchTokenPrices();
 
-  const { triggerWalletTokenBalancesReload } = useWatchWalletBalance();
+  const triggerWalletTokenBalancesReload = useWatchWalletBalance();
 
   const [cookies, setCookie] = useCookies([
     'terms-and-conditions-acceptance',

--- a/src/selectors/wallet.ts
+++ b/src/selectors/wallet.ts
@@ -1,0 +1,17 @@
+import { PublicKey } from '@solana/web3.js';
+import { createSelector } from 'reselect';
+
+import type { RootState } from '@/store/store';
+
+export const selectWalletAddress = (state: RootState) =>
+  state.walletState.wallet?.walletAddress ?? null;
+
+/**
+ * Memoize the computation of the base58 wallet address string to its
+ * PublicKey counterpart.
+ * - https://reselect.js.org/api/createselector/
+ */
+export const selectWalletPublicKey = createSelector(
+  [selectWalletAddress],
+  (walletAddress) => (walletAddress ? new PublicKey(walletAddress) : null),
+);


### PR DESCRIPTION
The `useWatchWalletBalance` is problematic: it's used in multiple places to fetch the amounts for multiple tokens for the currently used wallet.

For every component consuming this hook, a series of fetch & RPC calls are triggered concurrently, unnecessarily adding a lot of network / RPC usage overhead.

Additionally, the hook performs expensive computations related to PublicKeys, ie:
- instantiating a `PublicKey` for the current wallet address from its base58 string representation
- finding the ATA of a given mint for the current wallet public key

This second point is easily mitigated using cache at two levels:
- memoized redux selectors using [reselect](https://reselect.js.org/api/createselector/)
- a custom `WALLET_TO_ATAS_CACHE` / `getAtaFromCacheOrSet` mechanism which allows to re-use the result of the ATA computations for the currently connected wallet, relying on [WeakMap](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap) to prevent memory leak & ensuring garbage collection if/when the user disconnects or switch their wallet.

I also took the liberty of slightly simplifying a bit of convoluted async logic, as well as adding notes about solving the first problematic aspect of this hook's current implementation - which would have good impact on performance & also RPC usage / cost over time.

Note: requires testing multiple scenarios.